### PR TITLE
fix forward returning dict on single prediction

### DIFF
--- a/iTransformer/iTransformer.py
+++ b/iTransformer/iTransformer.py
@@ -264,7 +264,7 @@ class iTransformer(Module):
 
             return mse_loss
 
-        if len(pred_list) == 0:
+        if len(pred_list) == 1:
             return pred_list[0]
 
         pred_dict = dict(zip(self.pred_length, pred_list))


### PR DESCRIPTION
Fix `iTransformer.forward()` returns dict with single tensor instead of the tensor.
I guess this is a simple mistake.

https://github.com/lucidrains/iTransformer/blob/fdfa509d25e9b2b45f49d210611497a83338f2f5/iTransformer/iTransformer.py#L267-L268